### PR TITLE
Follow-ups & reminders

### DIFF
--- a/cogs/meeting.py
+++ b/cogs/meeting.py
@@ -259,15 +259,6 @@ class Meeting(commands.Cog, name="meeting"):
         """
         await self.addFollowUp(context.guild, context.message)
 
-    @commands.command(name="test-reminders")
-    @commands.has_role("Approved")
-    async def testReminders(self, context: Context):
-        """
-        Test the follow-up reminders feature
-        """
-        await self.remindFollowUps(context.guild, datetime.datetime.utcnow())
-
-
 # And then we finally add the cog to the bot so that it can load, unload, reload and use it's content.
 def setup(bot):
     bot.add_cog(Meeting(bot))

--- a/cogs/meeting.py
+++ b/cogs/meeting.py
@@ -265,15 +265,6 @@ class Meeting(commands.Cog, name="meeting"):
         """
         await self.addFollowUp(context.guild, context.message)
 
-    @commands.command(name="test-reminders")
-    @commands.has_role("Approved")
-    async def testReminders(self, context: Context):
-        """
-        Test the follow-up reminders feature
-        """
-        await self.remindFollowUps(context.guild, datetime.datetime.utcnow())
-
-
 # And then we finally add the cog to the bot so that it can load, unload, reload and use it's content.
 def setup(bot):
     bot.add_cog(Meeting(bot))


### PR DESCRIPTION
Assign someone a follow-up by using the !follow-up command and tagging them. When you !end-meeting the bot will post a summary to the #agenda-and-followups channel. Users can react to the summary post to mark themselves done. The bot will DM users reminders periodically after the meeting with the text of their follow-ups if they haven't marked themselves done. The times it reminds people is hardcoded but configurable in the constant tuple at the top of the file.